### PR TITLE
Upgrade @aantron/repromise to reason-promise

### DIFF
--- a/__tests__/EthTest.re
+++ b/__tests__/EthTest.re
@@ -17,95 +17,93 @@ let lastTx = ref("0x");
 
 beforeAllPromise(() =>
   coinbase(provider)
-  |> Repromise.map(result =>
-       switch (result) {
-       | Ok(address) =>
-         primaryAddress := address;
-         /* Js.log("address: " ++ primaryAddress^); */
-         ();
-       | Error(msg) => Js.log(msg)
-       }
-     )
-  |> Repromise.Rejectable.toJsPromise
+  ->Promise.map(result =>
+      switch (result) {
+      | Ok(address) =>
+        primaryAddress := address;
+        /* Js.log("address: " ++ primaryAddress^); */
+        ();
+      | Error(msg) => Js.log(msg)
+      }
+    )
+  ->Promise.Js.toBsPromise
 );
 
 describe("#blockNumber", () => {
   testPromise("fetches block", () =>
     blockNumber(provider)
-    |> Repromise.map(result =>
-         switch (result) {
-         | Ok(block) => expect(block) |> toBe(0)
-         | Error(msg) => fail(msg)
-         }
-       )
-    |> Repromise.Rejectable.toJsPromise
+    ->Promise.map(result =>
+        switch (result) {
+        | Ok(block) => expect(block) |> toBe(0)
+        | Error(msg) => fail(msg)
+        }
+      )
+    ->Promise.Js.toBsPromise
   );
 
   describe("updates block", () => {
-    beforeAllPromise(() =>
-      mineBlock(provider) |> Repromise.Rejectable.toJsPromise
-    );
+    beforeAllPromise(() => mineBlock(provider)->Promise.Js.toBsPromise);
 
     testPromise("updates block", () =>
       blockNumber(provider)
-      |> Repromise.map(result =>
-           switch (result) {
-           | Ok(block) => expect(block) |> toBe(1)
-           | Error(msg) => fail(msg)
-           }
-         )
-      |> Repromise.Rejectable.toJsPromise
+      ->Promise.map(result =>
+          switch (result) {
+          | Ok(block) => expect(block) |> toBe(1)
+          | Error(msg) => fail(msg)
+          }
+        )
+      ->Promise.Js.toBsPromise
     );
   });
 
   testPromise("fetches mainnet block", () =>
     blockNumber(infura)
-    |> Repromise.map(result =>
-         switch (result) {
-         | Ok(block) => expect(block) |> toBeGreaterThanOrEqual(7670624)
-         | Error(msg) => fail(msg)
-         }
-       )
-    |> Repromise.Rejectable.toJsPromise
+    ->Promise.map(result =>
+        switch (result) {
+        | Ok(block) => expect(block) |> toBeGreaterThanOrEqual(7670624)
+        | Error(msg) => fail(msg)
+        }
+      )
+    ->Promise.Js.toBsPromise
   );
 });
 
 describe("accounts", () =>
   testPromise("fetches accounts", () =>
     accounts(provider)
-    |> Repromise.map(result =>
-         switch (result) {
-         | Ok(accounts) =>
-           allAccounts := accounts;
-           expect(Belt.Array.length(accounts)) |> toEqual(10);
-         | Error(msg) => fail(msg)
-         }
-       )
-    |> Repromise.Rejectable.toJsPromise
+    ->Promise.map(result =>
+        switch (result) {
+        | Ok(accounts) =>
+          allAccounts := accounts;
+          expect(Belt.Array.length(accounts)) |> toEqual(10);
+        | Error(msg) => fail(msg)
+        }
+      )
+    ->Promise.Js.toBsPromise
   )
 );
 
 describe("#balanceOf", () => {
   testPromise("invalid address", () =>
     balanceOf(~provider, ~account="0x1234", ())
-    |> Repromise.map(result =>
-         switch (result) {
-         | Ok(_) => fail("this should not work")
-         | Error(msg) => msg |> expect |> toEqual("Invalid Address: 0x1234")
-         }
-       )
-    |> Repromise.Rejectable.toJsPromise
+    ->Promise.map(result =>
+        switch (result) {
+        | Ok(_) => fail("this should not work")
+        | Error(msg) => msg |> expect |> toEqual("Invalid Address: 0x1234")
+        }
+      )
+    ->Promise.Js.toBsPromise
   );
 
   testPromise("empty Balance", () =>
     balanceOf(~provider, ~account=randomAccount, ())
-    |> Repromise.map(result =>
-         switch (result) {
-         | Ok(amount) => expect(BigInt.toInt(amount)) |> toEqual(0)
-         | Error(msg) => fail(msg)
-         }
-       )
-    |> Repromise.Rejectable.toJsPromise
+    ->Promise.map(result =>
+        switch (result) {
+        | Ok(amount) => expect(BigInt.toInt(amount)) |> toEqual(0)
+        | Error(msg) => fail(msg)
+        }
+      )
+    ->Promise.Js.toBsPromise
   );
 
   testPromise("With Balance at block", () =>
@@ -115,29 +113,29 @@ describe("#balanceOf", () => {
       ~from=Formats.Block(0),
       (),
     )
-    |> Repromise.map(result =>
-         switch (result) {
-         | Ok(amount) =>
-           BigInt.toString(amount, 10)
-           |> expect
-           |> toEqual("100000000000000000000")
-         | Error(msg) => fail(msg)
-         }
-       )
-    |> Repromise.Rejectable.toJsPromise
+    ->Promise.map(result =>
+        switch (result) {
+        | Ok(amount) =>
+          BigInt.toString(amount, 10)
+          |> expect
+          |> toEqual("100000000000000000000")
+        | Error(msg) => fail(msg)
+        }
+      )
+    ->Promise.Js.toBsPromise
   );
 });
 
 describe("#transactionCount", () => {
   testPromise("with 1 transaction", () =>
     transactionCount(~provider, ~account=primaryAddress^, ())
-    |> Repromise.map(result =>
-         switch (result) {
-         | Ok(result) => result |> expect |> toEqual(0)
-         | Error(msg) => fail(msg)
-         }
-       )
-    |> Repromise.Rejectable.toJsPromise
+    ->Promise.map(result =>
+        switch (result) {
+        | Ok(result) => result |> expect |> toEqual(0)
+        | Error(msg) => fail(msg)
+        }
+      )
+    ->Promise.Js.toBsPromise
   );
 
   testPromise("with no transactions", () =>
@@ -147,29 +145,29 @@ describe("#transactionCount", () => {
       ~from=Formats.Block(0),
       (),
     )
-    |> Repromise.map(result =>
-         switch (result) {
-         | Ok(result) => result |> expect |> toEqual(0)
-         | Error(msg) => fail(msg)
-         }
-       )
-    |> Repromise.Rejectable.toJsPromise
+    ->Promise.map(result =>
+        switch (result) {
+        | Ok(result) => result |> expect |> toEqual(0)
+        | Error(msg) => fail(msg)
+        }
+      )
+    ->Promise.Js.toBsPromise
   );
 });
 
 describe("#gasPrice", () =>
   testPromise("fetches gas price in wei", () =>
     gasPrice(provider)
-    |> Repromise.map(result =>
-         switch (result) {
-         | Ok(result) =>
-           BigInt.toInt(result)
-           |> expect
-           |> toBeGreaterThanOrEqual(2000000000)
-         | Error(msg) => fail(msg)
-         }
-       )
-    |> Repromise.Rejectable.toJsPromise
+    ->Promise.map(result =>
+        switch (result) {
+        | Ok(result) =>
+          BigInt.toInt(result)
+          |> expect
+          |> toBeGreaterThanOrEqual(2000000000)
+        | Error(msg) => fail(msg)
+        }
+      )
+    ->Promise.Js.toBsPromise
   )
 );
 
@@ -186,15 +184,15 @@ describe("#sendTransaction", () =>
           (),
         ),
     )
-    |> Repromise.map(result =>
-         switch (result) {
-         | Ok(result) =>
-           lastTx := result;
-           String.length(result) |> expect |> toBe(66);
-         | Error(msg) => fail(msg)
-         }
-       )
-    |> Repromise.Rejectable.toJsPromise
+    ->Promise.map(result =>
+        switch (result) {
+        | Ok(result) =>
+          lastTx := result;
+          String.length(result) |> expect |> toBe(66);
+        | Error(msg) => fail(msg)
+        }
+      )
+    ->Promise.Js.toBsPromise
   )
 );
 
@@ -205,29 +203,29 @@ describe("#sendRawTransaction", () => {
       ~tx=
         "0xf864808207d08301e0f3942036c6cd85692f0fb2c26e6c6b2eced9e4478dfd8204cf001ca0f5d033ee6f1be4cca13379137234e7d1e620c4d268c679c560d5609dac6b3f15a06738dc64a3d7f4f419461b3dbfb0f0a26433ac4adbc45d636ba5bc81dc9f1028",
     )
-    |> Repromise.map(result =>
-         switch (result) {
-         | Ok(hash) =>
-           hash
-           |> expect
-           |> toEqual(
-                "0x218f5bab3339d03f52a202fb571c4a259482569163af0b61396b9d4b2e169985",
-              )
-         | Error(msg) => fail(msg)
-         }
-       )
-    |> Repromise.Rejectable.toJsPromise
+    ->Promise.map(result =>
+        switch (result) {
+        | Ok(hash) =>
+          hash
+          |> expect
+          |> toEqual(
+               "0x218f5bab3339d03f52a202fb571c4a259482569163af0b61396b9d4b2e169985",
+             )
+        | Error(msg) => fail(msg)
+        }
+      )
+    ->Promise.Js.toBsPromise
   );
 
   testPromise("fails with invalid transaction", () =>
     sendRawTransaction(~provider, ~tx="0x0")
-    |> Repromise.map(result =>
-         switch (result) {
-         | Ok(_) => fail("Bad transaction should not be accepted")
-         | Error(msg) => msg |> expect |> toEqual("Invalid Signature")
-         }
-       )
-    |> Repromise.Rejectable.toJsPromise
+    ->Promise.map(result =>
+        switch (result) {
+        | Ok(_) => fail("Bad transaction should not be accepted")
+        | Error(msg) => msg |> expect |> toEqual("Invalid Signature")
+        }
+      )
+    ->Promise.Js.toBsPromise
   );
 });
 
@@ -245,14 +243,14 @@ describe("#estimateGas", () =>
         ),
       (),
     )
-    |> Repromise.map(result =>
-         switch (result) {
-         | Ok(result) =>
-           BigInt.toString(result, 10) |> expect |> toBe("21000")
-         | Error(msg) => fail(msg)
-         }
-       )
-    |> Repromise.Rejectable.toJsPromise
+    ->Promise.map(result =>
+        switch (result) {
+        | Ok(result) =>
+          BigInt.toString(result, 10) |> expect |> toBe("21000")
+        | Error(msg) => fail(msg)
+        }
+      )
+    ->Promise.Js.toBsPromise
   )
 );
 
@@ -263,13 +261,13 @@ describe("#call", () => {
       ~tx=Formats.tx(~to_="0x160c5ce58e2cc4fe7cc45a9dd569a10083b2a275", ()),
       (),
     )
-    |> Repromise.map(result =>
-         switch (result) {
-         | Ok(result) => result |> expect |> toBe("0x")
-         | Error(msg) => fail(msg)
-         }
-       )
-    |> Repromise.Rejectable.toJsPromise
+    ->Promise.map(result =>
+        switch (result) {
+        | Ok(result) => result |> expect |> toBe("0x")
+        | Error(msg) => fail(msg)
+        }
+      )
+    ->Promise.Js.toBsPromise
   );
 
   testPromise("calls contract with data", () =>
@@ -284,48 +282,48 @@ describe("#call", () => {
       ~from=Formats.Block(5768167),
       (),
     )
-    |> Repromise.map(result =>
-         switch (result) {
-         | Ok(result) =>
-           result
-           |> expect
-           |> toBe(
-                "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000034241540000000000000000000000000000000000000000000000000000000000",
-              )
-         | Error(msg) => fail(msg)
-         }
-       )
-    |> Repromise.Rejectable.toJsPromise
+    ->Promise.map(result =>
+        switch (result) {
+        | Ok(result) =>
+          result
+          |> expect
+          |> toBe(
+               "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000034241540000000000000000000000000000000000000000000000000000000000",
+             )
+        | Error(msg) => fail(msg)
+        }
+      )
+    ->Promise.Js.toBsPromise
   );
 });
 
 describe("#transactionByHash", () =>
   testPromise("fetches TX", () =>
     transactionByHash(~provider, ~txHash=lastTx^)
-    |> Repromise.map(result =>
-         switch (result) {
-         | Ok(resp) =>
-           let pt: Formats.postedTx = resp;
-           pt.from |> expect |> toEqual(primaryAddress^);
-         | Error(msg) => fail(msg)
-         }
-       )
-    |> Repromise.Rejectable.toJsPromise
+    ->Promise.map(result =>
+        switch (result) {
+        | Ok(resp) =>
+          let pt: Formats.postedTx = resp;
+          pt.from |> expect |> toEqual(primaryAddress^);
+        | Error(msg) => fail(msg)
+        }
+      )
+    ->Promise.Js.toBsPromise
   )
 );
 
 describe("#transactionReceipt", () =>
   testPromise("fetches TX Receipt", () =>
     transactionReceipt(~provider, ~txHash=lastTx^)
-    |> Repromise.map(result =>
-         switch (result) {
-         | Ok(resp) =>
-           let pt: Formats.receipt = resp;
-           pt.from |> expect |> toEqual(primaryAddress^);
-         | Error(msg) => fail(msg)
-         }
-       )
-    |> Repromise.Rejectable.toJsPromise
+    ->Promise.map(result =>
+        switch (result) {
+        | Ok(resp) =>
+          let pt: Formats.receipt = resp;
+          pt.from |> expect |> toEqual(primaryAddress^);
+        | Error(msg) => fail(msg)
+        }
+      )
+    ->Promise.Js.toBsPromise
   )
 );
 
@@ -334,31 +332,30 @@ describe("#blocksByXXX", () => {
 
   testPromise("fetches Block by number", () =>
     blockByNumber(~provider, ~blockNumber=2, ~deep=true)
-    |> Repromise.map(blockResult =>
-         switch (blockResult) {
-         | Ok(blk) =>
-           lastBlock := Some(blk);
-           blk.Formats.number |> expect |> toEqual(2);
-         | Error(msg) => fail(msg)
-         }
-       )
-    |> Repromise.Rejectable.toJsPromise
+    ->Promise.map(blockResult =>
+        switch (blockResult) {
+        | Ok(blk) =>
+          lastBlock := Some(blk);
+          blk.Formats.number |> expect |> toEqual(2);
+        | Error(msg) => fail(msg)
+        }
+      )
+    ->Promise.Js.toBsPromise
   );
 
   testPromise("fetches Block by hash", () =>
     switch (lastBlock^) {
     | Some(blk1) =>
       blockByHash(~provider, ~blockHash=blk1.Formats.hash, ~deep=true)
-      |> Repromise.map(blockResult =>
-           switch (blockResult) {
-           | Ok(blk) => blk |> expect |> toEqual(blk1)
-           | Error(msg) => fail(msg)
-           }
-         )
-      |> Repromise.Rejectable.toJsPromise
+      ->Promise.map(blockResult =>
+          switch (blockResult) {
+          | Ok(blk) => blk |> expect |> toEqual(blk1)
+          | Error(msg) => fail(msg)
+          }
+        )
+      ->Promise.Js.toBsPromise
     | None =>
-      Repromise.Rejectable.resolved(fail("did not have ablock"))
-      |> Repromise.Rejectable.toJsPromise
+      Promise.resolved(fail("did not have ablock"))->Promise.Js.toBsPromise
     }
   );
 });
@@ -366,12 +363,12 @@ describe("#blocksByXXX", () => {
 describe("#netVersion", () =>
   testPromise("fetches version", () =>
     netVersion(infura)
-    |> Repromise.map(result =>
-         switch (result) {
-         | Ok(netId) => expect(netId) |> toEqual(1)
-         | Error(msg) => fail(msg)
-         }
-       )
-    |> Repromise.Rejectable.toJsPromise
+    ->Promise.map(result =>
+        switch (result) {
+        | Ok(netId) => expect(netId) |> toEqual(1)
+        | Error(msg) => fail(msg)
+        }
+      )
+    ->Promise.Js.toBsPromise
   )
 );

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -13,7 +13,7 @@
   "bs-dependencies": [
     "@glennsl/bs-json",
     "bs-fetch",
-    "@aantron/repromise"
+    "reason-promise"
   ],
   "bs-dev-dependencies": [
     "@glennsl/bs-jest"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "microbundle": "^0.11.0"
   },
   "dependencies": {
-    "@aantron/repromise": "^0.6.0",
+    "reason-promise": "^1.0.2",
     "@glennsl/bs-json": "^3.0.0",
     "bs-fetch": "^0.3.0",
     "isomorphic-fetch": "^2.2.1",

--- a/src/Eth.re
+++ b/src/Eth.re
@@ -2,143 +2,67 @@ open Formats;
 open Belt.Result;
 
 let coinbase = (provider: Providers.provider) =>
-  provider("eth_coinbase", [||])
-  |> Repromise.map(result =>
-       switch (result) {
-       | Ok(data) => Ok(Decode.address(data))
-       | Error(msg) => Error(msg)
-       }
-     );
+  provider("eth_coinbase", [||])->Promise.mapOk(Decode.address);
 
 let accounts = (provider: Providers.provider) =>
-  provider("eth_accounts", [||])
-  |> Repromise.map(result =>
-       switch (result) {
-       | Ok(data) => Ok(Decode.accounts(data))
-       | Error(msg) => Error(msg)
-       }
-     );
+  provider("eth_accounts", [||])->Promise.mapOk(Decode.accounts);
 
 let balanceOf =
     (~provider: Providers.provider, ~account: address, ~from=Latest, ()) =>
   if (validateAddress(account)) {
     let params = [|Encode.address(account), Encode.blockOrTag(from)|];
-    provider("eth_getBalance", params)
-    |> Repromise.map(result =>
-         switch (result) {
-         | Ok(data) => Ok(Decode.amount(data))
-         | Error(msg) => Error(msg)
-         }
-       );
+    provider("eth_getBalance", params)->Promise.mapOk(Decode.amount);
   } else {
-    Repromise.resolved(Error("Invalid Address: " ++ account));
+    Promise.resolved(Error("Invalid Address: " ++ account));
   };
 
 let transactionCount =
     (~provider: Providers.provider, ~account: address, ~from=Latest, ()) =>
   if (validateAddress(account)) {
     let params = [|Encode.address(account), Encode.blockOrTag(from)|];
-    provider("eth_getTransactionCount", params)
-    |> Repromise.map(result =>
-         switch (result) {
-         | Ok(data) => Ok(Decode.nonce(data))
-         | Error(msg) => Error(msg)
-         }
-       );
+    provider("eth_getTransactionCount", params)->Promise.mapOk(Decode.nonce);
   } else {
-    Repromise.resolved(Error("Invalid Address: " ++ account));
+    Promise.resolved(Error("Invalid Address: " ++ account));
   };
 
 let blockNumber = (provider: Providers.provider) =>
-  provider("eth_blockNumber", [||])
-  |> Repromise.map(result =>
-       switch (result) {
-       | Ok(data) => Ok(Decode.blockNumber(data))
-       | Error(msg) => Error(msg)
-       }
-     );
+  provider("eth_blockNumber", [||])->Promise.mapOk(Decode.blockNumber);
 
 let gasPrice = (provider: Providers.provider) =>
-  provider("eth_gasPrice", [||])
-  |> Repromise.map(result =>
-       switch (result) {
-       | Ok(data) => Ok(Decode.amount(data))
-       | Error(msg) => Error(msg)
-       }
-     );
+  provider("eth_gasPrice", [||])->Promise.mapOk(Decode.amount);
 
 let sendTransaction = (~provider: Providers.provider, ~tx) => {
   let params = [|Encode.transaction(tx)|];
-  provider("eth_sendTransaction", params)
-  |> Repromise.map(result =>
-       switch (result) {
-       | Ok(data) => Ok(Decode.data(data))
-       | Error(msg) => Error(msg)
-       }
-     );
+  provider("eth_sendTransaction", params)->Promise.mapOk(Decode.data);
 };
 
 let sendRawTransaction = (~provider: Providers.provider, ~tx: Formats.data) => {
   let params = [|Encode.data(tx)|];
-  provider("eth_sendRawTransaction", params)
-  |> Repromise.map(result =>
-       switch (result) {
-       | Ok(data) => Ok(Decode.data(data))
-       | Error(msg) => Error(msg)
-       }
-     );
+  provider("eth_sendRawTransaction", params)->Promise.mapOk(Decode.data);
 };
 
 let transactionByHash =
     (~provider: Providers.provider, ~txHash: Formats.txHash) =>
   provider("eth_getTransactionByHash", [|Encode.data(txHash)|])
-  |> Repromise.map(result =>
-       switch (result) {
-       | Ok(data) => Ok(Decode.transaction(data))
-       | Error(msg) => Error(msg)
-       }
-     );
+  ->Promise.mapOk(Decode.transaction);
 
 let transactionReceipt =
     (~provider: Providers.provider, ~txHash: Formats.txHash) =>
   provider("eth_getTransactionReceipt", [|Encode.data(txHash)|])
-  |> Repromise.map(result =>
-       switch (result) {
-       | Ok(data) => Ok(Decode.receipt(data))
-       | Error(msg) => Error(msg)
-       }
-     );
+  ->Promise.mapOk(Decode.receipt);
 
 let estimateGas = (~provider: Providers.provider, ~tx, ~from=Latest, ()) => {
   let params = [|Encode.transaction(tx), Encode.blockOrTag(from)|];
-  provider("eth_estimateGas", params)
-  |> Repromise.map(result =>
-       switch (result) {
-       | Ok(data) => Ok(Decode.amount(data))
-       | Error(msg) => Error(msg)
-       }
-     );
+  provider("eth_estimateGas", params)->Promise.mapOk(Decode.amount);
 };
 
 let call = (~provider: Providers.provider, ~tx, ~from=Latest, ()) => {
   let params = [|Encode.transaction(tx), Encode.blockOrTag(from)|];
-  provider("eth_call", params)
-  |> Repromise.map(result =>
-       switch (result) {
-       | Ok(data) => Ok(Decode.data(data))
-       | Error(msg) => Error(msg)
-       }
-     );
+  provider("eth_call", params)->Promise.mapOk(Decode.data);
 };
 
 let mineBlock = (provider: Providers.provider) =>
-  provider("evm_mine", [||])
-  |> Repromise.map(result =>
-       switch (result) {
-       | Ok(data) => Ok(Decode.string(data))
-       | Error(msg) => Error(msg)
-       }
-     );
+  provider("evm_mine", [||])->Promise.mapOk(Decode.string);
 
 let blockByHash =
     (
@@ -150,12 +74,7 @@ let blockByHash =
     "eth_getBlockByHash",
     [|Encode.data(blockHash), Encode.bool(deep)|],
   )
-  |> Repromise.map(result =>
-       switch (result) {
-       | Ok(data) => Ok(Decode.block(data))
-       | Error(msg) => Error(msg)
-       }
-     );
+  ->Promise.mapOk(Decode.block);
 
 let blockByNumber =
     (
@@ -167,18 +86,7 @@ let blockByNumber =
     "eth_getBlockByNumber",
     [|Encode.quantity(blockNumber), Encode.bool(deep)|],
   )
-  |> Repromise.map(result =>
-       switch (result) {
-       | Ok(data) => Ok(Decode.block(data))
-       | Error(msg) => Error(msg)
-       }
-     );
+  ->Promise.mapOk(Decode.block);
 
 let netVersion = (provider: Providers.provider) =>
-  provider("net_version", [||])
-  |> Repromise.map(result =>
-       switch (result) {
-       | Ok(data) => Ok(Decode.quantity(data))
-       | Error(msg) => Error(msg)
-       }
-     );
+  provider("net_version", [||])->Promise.mapOk(Decode.quantity);

--- a/src/Providers.re
+++ b/src/Providers.re
@@ -34,17 +34,17 @@ let handleResponse = (json): rpcResult => {
   };
 };
 
-type provider = (string, Js.Array.t(Js.Json.t)) => Repromise.t(rpcResult);
+type provider = (string, Js.Array.t(Js.Json.t)) => Promise.t(rpcResult);
 
 let http = (url): provider =>
   (method, params) =>
     ReFetch.fetchJson(url, toRequest(method, params))
-    |> Repromise.map(response =>
-         switch (response) {
-         | Ok(json) => handleResponse(json)
-         | Error(error) => Error(error)
-         }
-       );
+    ->Promise.map(response =>
+        switch (response) {
+        | Ok(json) => handleResponse(json)
+        | Error(error) => Error(error)
+        }
+      );
 
 module Web3provider = {
   type t;
@@ -53,7 +53,7 @@ module Web3provider = {
 };
 
 let web3 = (web3p: Web3provider.t, method, params) => {
-  let (p, resolve_p) = Repromise.make();
+  let (p, resolve_p) = Promise.pending();
   Web3provider.sendAsync(web3p, toRequest(method, params), (error, response) =>
     resolve_p(
       switch (Js.Nullable.toOption(error), Js.Nullable.toOption(response)) {

--- a/src/ReFetch.re
+++ b/src/ReFetch.re
@@ -3,7 +3,7 @@
 open Belt.Result;
 
 let fetchJson = (url, payload) => {
-  Repromise.Rejectable.fromJsPromise(
+  Promise.Js.fromBsPromise(
     Fetch.fetchWithInit(
       url,
       Fetch.RequestInit.make(
@@ -15,11 +15,7 @@ let fetchJson = (url, payload) => {
       ),
     ),
   )
-  |> Repromise.Rejectable.andThen(r =>
-       Repromise.Rejectable.fromJsPromise(Fetch.Response.json(r))
-     )
-  |> Repromise.Rejectable.map(json => Ok(json))
-  |> Repromise.Rejectable.catch(_ =>
-       Repromise.Rejectable.resolved(Error("Error"))
-     );
+  ->Promise.Js.flatMap(r => Promise.Js.fromBsPromise(Fetch.Response.json(r)))
+  ->Promise.Js.map(json => Ok(json))
+  ->Promise.Js.catch(_ => Promise.Js.resolved(Error("Error")));
 };


### PR DESCRIPTION
Repromise became [reason-promise](https://github.com/aantron/promise) in 1.0.0. The API was renamed (e.g., `Repromise.wait` is now `Promise.get`), rearranged to prefer `->` instead of `|>`, and helpers were added for `Result` and `Option`, as well as some miscellaneous ones. The bundle size was reduced to 1K. See the [changelog](https://github.com/aantron/promise/releases/tag/1.0.0) here; there are also two subsequent bugfix releases.

This PR adapts this repo to use reason-promise. The changes are mostly renamings. However, a lot of repetitive code was removed from `Eth.re` by using the new `Promise.mapOk`.